### PR TITLE
Fix minor security bugs

### DIFF
--- a/vulnet.c
+++ b/vulnet.c
@@ -45,7 +45,7 @@ int readSock( int sockfd, char* buf, size_t bufLen )
 
     r = recv( sockfd, buf, bufLen - 1, 0 );
     if ( r == -1 ) { perror( "recv" ); return -1; }
-    buf[r - 1] = '\0';
+    if ( r > 0 ) buf[r - 1] = '\0';
     return 0;
 }
 

--- a/vulnet.c
+++ b/vulnet.c
@@ -56,7 +56,7 @@ int authenticate( int sockfd, const char* id, const char* pw )
     const char* szWrongID = "Wrong ID given.\n";
     const char* szPass = "Password: ";
     const char* szWrongPW = "Wrong Password given.\n";
-    char buf[MAX_BUF];
+    char buf[MAX_BUF] = {'\0', };
 
     r = send( sockfd, szName, strlen( szName ), 0 );
     if ( r == -1 ) { perror( "send" ); return -1; }


### PR DESCRIPTION
1.  Uninitialized local variable in authenticate
     - After valid user's login, adversary can detect id == pw or not.
2. Null byte underflow in readSock fucntion
     - We can make bug It cannot be used to exploit but it may better to fix it.
